### PR TITLE
Add cookie parser middleware

### DIFF
--- a/circlet_lib.janet
+++ b/circlet_lib.janet
@@ -33,6 +33,23 @@
     (print proto " " method " " status " " fulluri " elapsed " elapsed "ms")
     ret))
 
+(defn cookies
+  "Parses cookies into the table under :cookies key"
+  [nextmw]
+  (fn [req]
+    (-> req
+      (put :cookies
+           (or
+             (-?>> [:headers "Cookie"] 
+                   (get-in req) 
+                   (string/split ";") 
+                   (map |(string/split "=" $)) 
+                   flatten 
+                   (map string/trim) 
+                   (apply table))
+             {}))
+     nextmw)))
+
 (defn server 
   "Creates a simple http server"
   [handler port &opt ip-address]


### PR DESCRIPTION
This PR adds a simple prototype for cookie parsing middleware.

In https://github.com/pepe/janet-playground/blob/727eb4b453ca9bfe087dda7fed2057f91afe7011/circlet-server.janet#L32, one can see its usage. With slightly different name :-).