### PR TITLE
fixes #8 - Uses mg_bind_opt for error handling

### DIFF
--- a/circlet_lib.janet
+++ b/circlet_lib.janet
@@ -57,7 +57,7 @@
   [handler port &opt ip-address]
   (def mgr (manager))
   (def mw (middleware handler))
-  (default ip-address "localhost")
+  (default ip-address "127.0.0.1")
   (def interface (if (peg/match "*" ip-address)
                    (string port)
                    (string/format "%s:%d" ip-address port)))


### PR DESCRIPTION
Also adds a default case for specifically Windows to use loopback
address instead of localhost