### PR TITLE
added websocket support

### DIFF
--- a/circlet.c
+++ b/circlet.c
@@ -298,7 +298,7 @@ static Janet cfun_bind_http(int32_t argc, Janet *argv) {
 
 
 static int is_websocket(const struct mg_connection *nc) {
-  return nc->flags & MG_F_IS_WEBSOCKET;
+    return nc->flags & MG_F_IS_WEBSOCKET;
 }
 
 static Janet build_websocket_event(struct mg_connection *c, Janet event, struct websocket_message *wm) {
@@ -369,15 +369,15 @@ static Janet cfun_bind_http_websocket(int32_t argc, Janet *argv) {
 }
 
 static Janet cfun_broadcast(int32_t argc, Janet *argv) {
-  janet_fixarity(argc, 2);
-  struct mg_mgr *mgr = janet_getabstract(argv, 0, &Manager_jt);
-  const char *buf = janet_getcstring(argv, 1);
-  struct mg_connection *c;
-  for (c = mg_next(mgr, NULL); c != NULL; c = mg_next(mgr, c)) {
-    mg_send_websocket_frame(c, WEBSOCKET_OP_TEXT, buf, strlen(buf));
-  }
+    janet_fixarity(argc, 2);
+    struct mg_mgr *mgr = janet_getabstract(argv, 0, &Manager_jt);
+    const char *buf = janet_getcstring(argv, 1);
+    struct mg_connection *c;
+    for (c = mg_next(mgr, NULL); c != NULL; c = mg_next(mgr, c)) {
+      mg_send_websocket_frame(c, WEBSOCKET_OP_TEXT, buf, strlen(buf));
+    }
 
-  return argv[0];
+    return argv[0];
 }
 
 static const JanetReg cfuns[] = {


### PR DESCRIPTION
I attempted to create support for websocket that would:
- not interfere with current interface
- allow for http and websocket on same port

Currently one would start a websocket+http server like this:
```
(defn ws-handler
  [mgr {:data data :event event}] # event is :open, :close or :message. data is only set when :event is :message
  (when data
    (circlet/broadcast mgr data)))

(circlet/server-websocket
  myserver  # regular http handler
  ws-handler
  8000)
```

Some things I'm uncertain about:
- open / close / message are a bit different, so I'm not sure it makes sense to have a single handler for them. atm one has to check the data or event field
- I add the mgr when calling the ws-handler, since it is needed e.g. for broadcast. not sure this is best way to expose this

Alternative approaches considered:
- instead of a single function, one could have a struct with :open, :close and :message. but I wanted to stay close to current approach
- using the same handler for both http / websocket. I felt this didn't make much sense, since http requests wants to send a response, whereas websockets won't.
- putting websocket messages on ev/thread-chan. I think this makes a lot of sense, but it is easy to do with current implementation, so felt it was unnecessary

Problems:
- now there's no apparent way on how to get the mgr value without getting a message first. I think this might not matter much as long as the server is blocking.



I'm happy for any thoughts surrounding this, my goal was to get it to a point where it works, then we can continue from here. :)